### PR TITLE
fix: selenium webdriver HTTPConnectionPool 에러 해결 #17

### DIFF
--- a/backend/src/services/openGoKr.py
+++ b/backend/src/services/openGoKr.py
@@ -115,7 +115,7 @@ def crawlSingleConfig(
             )
         except TimeoutException:
             print(
-                f"기관+지역에 매칭되는 요소 없음. 정상 종료. {location}-{organization}",
+                f"기관+지역에 매칭되는 요소 없음. 다음 config로 진행. {location}-{organization}",
                 flush=True,
             )
             excel.notFoundData(
@@ -123,7 +123,6 @@ def crawlSingleConfig(
             )
             excel.pretterColumns()
             excel.save()
-            browser.close()
             return
         # 확인 버튼 클릭 (새 창 자동으로 닫힘)
         browser.clickElement("xpath", '//*[@id="popup_wrap"]/div[2]/div[2]/div[5]/a[1]')
@@ -159,7 +158,6 @@ def crawlSingleConfig(
             excel.notFoundData(query, organization, "검색 결과가 0건입니다.")
             excel.pretterColumns()
             excel.save()
-            browser.close()
             return
         browser.clickElement("xpath", '//*[@id="infoList"]')
         curPageIdx = 1


### PR DESCRIPTION
## Summary
- selenium webdriver가 각 config 처리 중 중복으로 종료되어 발생하는 HTTPConnectionPool Max retries exceeded 에러 해결
- 기관+지역 매칭 실패 시와 검색 결과 0건 시에 `browser.close()` 호출을 제거
- 모든 config 처리 완료 후에만 finally 블록에서 webdriver 종료하도록 수정

## 변경사항
- `crawlSingleConfig` 함수에서 중간 return 시 `browser.close()` 제거 (2곳)
- 로그 메시지를 "정상 종료"에서 "다음 config로 진행"으로 변경

## 테스트 플랜
- [x] 윈도우 환경에서 여러 config가 포함된 크롤링 테스트
- [x] 기관+지역 매칭 실패 케이스에서 다음 config 진행 확인  
- [x] 검색 결과 0건 케이스에서 다음 config 진행 확인
- [x] HTTPConnectionPool 에러 재발하지 않는지 확인

Closes #17

🤖 Generated with [Claude Code](https://claude.ai/code)