### PR TITLE
[feature/nara-g2b] 검색 결과가 1000을 넘어가면 NaN으로 인해 발생하는 에러 대응

### DIFF
--- a/frontend/electron/services/NaraG2b.service.ts
+++ b/frontend/electron/services/NaraG2b.service.ts
@@ -148,7 +148,9 @@ class NaraG2bService {
     await this.delay(1000);
 
     await page.waitForSelector("span#mf_wfm_container_tbxTotCnt");
-    const totalCnt = await page.$eval("span#mf_wfm_container_tbxTotCnt", (span) => Number(span.innerText));
+    const totalCnt = await page.$eval("span#mf_wfm_container_tbxTotCnt", (span) =>
+      parseInt(span.innerText.replace(/,/g, ""))
+    );
     this.loggingService.logging(`검색 결과: ${totalCnt}개`);
 
     if (totalCnt === 0) {


### PR DESCRIPTION
## Summary

나라장터(G2B) 크롤링에서 검색 결과가 1,000건 이상일 때 발생하는 숫자 파싱 오류를 수정합니다.

### 🐛 문제점
- 검색 결과 개수가 1,000을 넘어가면 `toLocaleString()`으로 인해 "1,000"과 같이 쉼표가 포함된 문자열로 표시됨
- 기존 `Number()` 함수로는 쉼표가 포함된 문자열을 올바르게 파싱하지 못해 `NaN` 반환
- 이로 인해 크롤링 프로세스가 중단되는 문제 발생

### 🔧 해결 방안
- `Number(span.innerText)` → `parseInt(span.innerText.replace(/,/g, ""))`로 변경
- 쉼표를 모두 제거한 후 정수로 파싱하여 정확한 숫자 추출

### 📍 변경 위치
`frontend/electron/services/NaraG2b.service.ts:151`

```typescript
// Before
const totalCnt = await page.$eval("span#mf_wfm_container_tbxTotCnt", (span) => Number(span.innerText));

// After  
const totalCnt = await page.$eval("span#mf_wfm_container_tbxTotCnt", (span) =>
  parseInt(span.innerText.replace(/,/g, ""))
);
```

🤖 Generated with [Claude Code](https://claude.ai/code)